### PR TITLE
Add support for additional versions of Python

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,5 @@ source = http_crawler
 [report]
 fail_under = 100
 show_missing = True
+exclude_lines =
+    .*:.* # Python \d.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@ matrix:
     - python: 3.5
       env: TOXENV=flake8
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - .tox
+
 script:
 - tox
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
+    - python: 3.5
+      env: TOXENV=flake8
 
 script:
 - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: python
-python:
-- '3.5'
+
 install:
 - pip install tox
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+
 script:
 - tox
 deploy:

--- a/src/http_crawler/__init__.py
+++ b/src/http_crawler/__init__.py
@@ -1,5 +1,9 @@
 import cgi
-from urllib.parse import urldefrag, urljoin, urlparse
+
+try:
+    from urllib.parse import urldefrag, urljoin, urlparse
+except ImportError:  # Python 2
+    from urlparse import urldefrag, urljoin, urlparse
 
 import lxml.html
 import requests

--- a/tests/test_http_crawler.py
+++ b/tests/test_http_crawler.py
@@ -27,8 +27,13 @@ def serve():
         server = HTTPServer(('', port), SimpleHTTPRequestHandler)
         server.serve_forever()
 
-    Process(target=_serve, args=('site', 8000), daemon=True).start()
-    Process(target=_serve, args=('external-site', 8001), daemon=True).start()
+    proc_site = Process(target=_serve, args=('site', 8000))
+    proc_site.daemon = True
+    proc_site.start()
+
+    proc_external_site = Process(target=_serve, args=('external-site', 8001))
+    proc_external_site.daemon = True
+    proc_external_site.start()
 
 
 def test_crawl():

--- a/tests/test_http_crawler.py
+++ b/tests/test_http_crawler.py
@@ -1,4 +1,9 @@
-from http.server import SimpleHTTPRequestHandler, HTTPServer
+try:
+    from http.server import SimpleHTTPRequestHandler, HTTPServer
+except ImportError:  # Python 2
+    from SimpleHTTPServer import SimpleHTTPRequestHandler
+    from BaseHTTPServer import HTTPServer
+
 import os
 from multiprocessing import Process
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,py35,flake8,coverage-report
+envlist = coverage-clean,py27,py34,py35,py36,flake8,coverage-report
 
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands = {posargs:coverage run -m pytest}
 
 
 [testenv:flake8]
+basepython = python3.5
 deps = flake8
 skip_install = true
 commands = flake8 src tests setup.py


### PR DESCRIPTION
I added 2.7 support (because I need it for another project), and 3.4 and 3.6, which are the two other major versions of 3.x currently in support. Plus testing in Travis.

Resolves #1.