### PR TITLE
Cut a new release with Python 2.7 support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Release History
 ===============
 
+0.2.0 (2017-10-09)
+******************
+
+This release has no changes to the public API, but adds support for Python 2.7 and Python 3.4 to 3.6.
+
 0.1.6 (2017-08-19)
 ******************
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,37 @@
+Release History
+===============
+
+0.1.6 (2017-08-19)
+******************
+
+- Fix a bug where ``crawl()`` would crash if it encountered an invalid URL scheme (e.g. ``mailto:`` links).
+
+0.1.5 (2017-02-09)
+******************
+
+- Remove a stray ``print()`` statement from inside ``crawl()``.
+
+0.1.4 (2017-02-09)
+******************
+
+This release is equivalent to 0.1.3, and just serves as a test of Travis deployments to PyPI.
+
+0.1.3 (2017-02-09)
+******************
+
+- Add the ``ignore_fragments`` parameter to ``crawl()``.
+
+0.1.2 (2016-08-10)
+******************
+
+- Add the ability to follow ``@font-face`` rules in CSS stylesheets.
+
+0.1.1 (2016-07-07)
+******************
+
+- Add the ``follow_external_links`` parameter to ``crawl()``.
+
+0.1.0 (2016-06-09)
+******************
+
+- First release!

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.6
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/src/http_crawler/__init__.py
+++ b/src/http_crawler/__init__.py
@@ -10,7 +10,7 @@ import requests
 import tinycss2
 
 
-__version__ = '0.1.6'
+__version__ = '0.2.0'
 
 
 def crawl(base_url, follow_external_links=True, ignore_fragments=True):


### PR DESCRIPTION
Follows #14. Now Python 2.7 is supported, put it in a version on PyPI!

This patch adds a changelog, bumps the version, and includes a 'v0.2.0' tag which Travis’s deployment feature should use to trigger uploading a new release to PyPI. \*crosses fingers*